### PR TITLE
fix: support multi-round processing & incremental build

### DIFF
--- a/compiler/src/main/kotlin/codegen/FactoryClass.kt
+++ b/compiler/src/main/kotlin/codegen/FactoryClass.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Meowool <https://github.com/meowool/mmkv-ktx/graphs/contributors>
+ * Copyright (C) 2024 Meowool <https://github.com/meowool/mmkv-ktx/graphs/contributors>
  *
  * This file is part of the MMKV-KTX project <https://github.com/meowool/mmkv-ktx>.
  *
@@ -27,13 +27,13 @@ import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 
-open class FactoryClass(override val context: Context) : Codegen() {
+open class FactoryClass : CodegenStep() {
   override fun generate() {
     val className = context.factoryClassName
     val classBuilder = TypeSpec.interfaceBuilder(className)
-    val preferences = context.preferences.toList()
+    val preferences = context.preferences
 
-    preferences.forEach {
+    preferences.process {
       val propertySpec = PropertySpec.builder(
         name = it.preferencesName(),
         type = context.preferencesClassName(it),

--- a/compiler/src/main/kotlin/codegen/FactoryImplClass.kt
+++ b/compiler/src/main/kotlin/codegen/FactoryImplClass.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Meowool <https://github.com/meowool/mmkv-ktx/graphs/contributors>
+ * Copyright (C) 2024 Meowool <https://github.com/meowool/mmkv-ktx/graphs/contributors>
  *
  * This file is part of the MMKV-KTX project <https://github.com/meowool/mmkv-ktx>.
  *
@@ -24,16 +24,16 @@ import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 
-class FactoryImplClass(context: Context) : FactoryClass(context) {
+class FactoryImplClass : FactoryClass() {
   override fun generate() {
     val className = context.factoryImplClassName
     val classBuilder = TypeSpec.classBuilder(className)
       .addModifiers(KModifier.INTERNAL)
       .addSuperinterface(context.factoryClassName)
       .addAnnotation(PublishedApi::class)
-    val preferences = context.preferences.toList()
+    val preferences = context.preferences
 
-    preferences.forEach {
+    preferences.process {
       val propertyName = it.preferencesName()
       val type = context.preferencesClassName(it)
       val typeNullable = type.copy(nullable = true)

--- a/compiler/src/main/kotlin/codegen/MutableClasses.kt
+++ b/compiler/src/main/kotlin/codegen/MutableClasses.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Meowool <https://github.com/meowool/mmkv-ktx/graphs/contributors>
+ * Copyright (C) 2024 Meowool <https://github.com/meowool/mmkv-ktx/graphs/contributors>
  *
  * This file is part of the MMKV-KTX project <https://github.com/meowool/mmkv-ktx>.
  *
@@ -28,8 +28,8 @@ import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.toTypeName
 
-class MutableClasses(override val context: Context) : Codegen() {
-  override fun generate() = context.preferences.forEach(::generateMutableClass)
+class MutableClasses : CodegenStep() {
+  override fun generate() = context.preferences.process(::generateMutableClass)
 
   private fun generateMutableClass(preferences: KSClassDeclaration) {
     val className = context.mutableClassName(preferences)

--- a/compiler/src/main/kotlin/codegen/PreferencesClasses.kt
+++ b/compiler/src/main/kotlin/codegen/PreferencesClasses.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Meowool <https://github.com/meowool/mmkv-ktx/graphs/contributors>
+ * Copyright (C) 2024 Meowool <https://github.com/meowool/mmkv-ktx/graphs/contributors>
  *
  * This file is part of the MMKV-KTX project <https://github.com/meowool/mmkv-ktx>.
  *
@@ -30,8 +30,8 @@ import com.squareup.kotlinpoet.UNIT
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.LambdaTypeName.Companion.get as lambdaType
 
-class PreferencesClasses(override val context: Context) : Codegen() {
-  override fun generate() = context.preferences.forEach(::generatePreferences)
+class PreferencesClasses : CodegenStep() {
+  override fun generate() = context.preferences.process(::generatePreferences)
 
   private fun generatePreferences(preferences: KSClassDeclaration) {
     val className = context.preferencesClassName(preferences)

--- a/compiler/src/main/kotlin/codegen/PreferencesImplClasses.kt
+++ b/compiler/src/main/kotlin/codegen/PreferencesImplClasses.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Meowool <https://github.com/meowool/mmkv-ktx/graphs/contributors>
+ * Copyright (C) 2024 Meowool <https://github.com/meowool/mmkv-ktx/graphs/contributors>
  *
  * This file is part of the MMKV-KTX project <https://github.com/meowool/mmkv-ktx>.
  *
@@ -59,8 +59,8 @@ import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.LambdaTypeName.Companion.get as lambdaType
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy as by
 
-class PreferencesImplClasses(override val context: Context) : Codegen() {
-  override fun generate() = context.preferences.forEach(::generatePreferences)
+class PreferencesImplClasses : CodegenStep() {
+  override fun generate() = context.preferences.process(::generatePreferences)
 
   private fun generatePreferences(preferences: KSClassDeclaration) {
     val dataClassName = preferences.toClassName()


### PR DESCRIPTION
Before this, any modification would cause KSP to be unable to find the `TypeConverter`.